### PR TITLE
Ability to render latex with MathJax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+scripts.go
 themes.go
 *.pdf

--- a/scripts/include_scripts.go
+++ b/scripts/include_scripts.go
@@ -1,0 +1,27 @@
+package main 
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	out, _ := os.Create("scripts.go")
+	out.Write([]byte("package main\n\n"))
+	out.Write([]byte("const MATHJAX_SCRIPT = `\n"))
+    out.WriteString(fmt.Sprintf(`
+        <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+            TeX: {extensions: ["mhchem.js"]},
+            tex2jax: {
+            inlineMath: [['$','$'], ['\\(','\\)']],
+            displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+            processEscapes: true
+            }
+        });
+        </script>
+        <script type="text/javascript"
+            src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML">
+        </script>`))
+	out.Write([]byte("`\n"))
+}

--- a/themes/github.css
+++ b/themes/github.css
@@ -239,6 +239,7 @@
 }
 .markdown-body img {
   max-width: 100%;
+  max-height: 100%;
 }
 .markdown-body strong {
   font-weight: bold;


### PR DESCRIPTION
close #2 

Add ability to render latex with MathJax.

The current theme used does not support math's equations correctly (ugly tbh). I decided to use MathJax's default renderer, by not added the script to the markdown converter. 

Here an example of output:

<img width="822" alt="image" src="https://github.com/user-attachments/assets/2aa6d4ec-66bd-479f-b82b-f82ee464acdb">
